### PR TITLE
fix: safe.bareRepository

### DIFF
--- a/dist/setup_flutter.ps1
+++ b/dist/setup_flutter.ps1
@@ -41,7 +41,6 @@ git clone --bare "$OriginUrl" .bare
 Set-Content -Path .git -Value "gitdir: ./.bare" -Encoding Ascii
 
 # 3. Configure Remotes
-Set-Location .bare
 Write-Host "⚙️  Configuring remotes..." -ForegroundColor Yellow
 
 # Fix Origin and Add Upstream
@@ -52,9 +51,6 @@ git config remote.upstream.fetch "+refs/heads/*:refs/remotes/upstream/*"
 # 4. Fetch All
 Write-Host "⬇️  Fetching everything (--all --tags --prune)..." -ForegroundColor Yellow
 git fetch --all --tags --prune
-
-# 5. Create Worktrees
-Set-Location ..
 
 # --- Setup MASTER ---
 Write-Host "🌲 Creating 'master' worktree..." -ForegroundColor Green
@@ -77,7 +73,7 @@ if ($setupStable -match "^[yY]") {
     git worktree add -B stable stable --track upstream/"$RefStable"
 }
 
-# 6. Pre-load Artifacts
+# 5. Pre-load Artifacts
 # Determine correct flutter command based on OS for cross-platform compatibility
 $flutterCmd = if ($IsWindows) { ".\bin\flutter.bat" } else { "./bin/flutter" }
 if ($setupStable -match "^[yY]") {
@@ -92,7 +88,7 @@ Set-Location master
 & $flutterCmd --version | Out-Null
 Set-Location ..
 
-# 7. Generate The Switcher Script
+# 6. Generate The Switcher Script
 Write-Host "🔗 Generating context switcher..." -ForegroundColor Cyan
 $SwitchFile = Join-Path $RootPath "fswitch.ps1"
 

--- a/dist/setup_flutter.sh
+++ b/dist/setup_flutter.sh
@@ -37,7 +37,6 @@ git clone --bare "$ORIGIN_URL" .bare
 echo "gitdir: ./.bare" > .git
 
 # 3. Configure Remotes
-cd .bare
 echo "⚙️  Configuring remotes..."
 git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
 git remote add upstream "$UPSTREAM_URL"
@@ -46,9 +45,6 @@ git config remote.upstream.fetch "+refs/heads/*:refs/remotes/upstream/*"
 # 4. Fetch tags / branches
 echo "⬇️  Fetching everything (--all --tags --prune)..."
 git fetch --all --tags --prune
-
-# 5. Create Worktrees
-cd ..
 
 # --- Setup MASTER ---
 echo "🌲 Creating 'master' worktree (tracking upstream/master)..."
@@ -66,7 +62,7 @@ else
     SETUP_STABLE=false
 fi
 
-# 6. Pre-load Artifacts
+# 5. Pre-load Artifacts
 # We run --version to download the engine/dart-sdk for both immediately
 if [ "$SETUP_STABLE" = true ]; then
     echo "🛠️  Hydrating 'stable' artifacts..."
@@ -80,7 +76,7 @@ cd master
 ./bin/flutter --version > /dev/null
 cd ..
 
-# 7. Generate The Switcher Script
+# 6. Generate The Switcher Script
 echo "🔗 Generating context switcher..."
 SWITCH_FILE="$ROOT_PATH/fswitch.sh"
 

--- a/setup_flutter.template.ps1
+++ b/setup_flutter.template.ps1
@@ -41,7 +41,6 @@ git clone --bare "$OriginUrl" .bare
 Set-Content -Path .git -Value "gitdir: ./.bare" -Encoding Ascii
 
 # 3. Configure Remotes
-Set-Location .bare
 Write-Host "⚙️  Configuring remotes..." -ForegroundColor Yellow
 
 # Fix Origin and Add Upstream
@@ -52,9 +51,6 @@ git config remote.upstream.fetch "+refs/heads/*:refs/remotes/upstream/*"
 # 4. Fetch All
 Write-Host "⬇️  Fetching everything (--all --tags --prune)..." -ForegroundColor Yellow
 git fetch --all --tags --prune
-
-# 5. Create Worktrees
-Set-Location ..
 
 # --- Setup MASTER ---
 Write-Host "🌲 Creating 'master' worktree..." -ForegroundColor Green
@@ -77,7 +73,7 @@ if ($setupStable -match "^[yY]") {
     git worktree add -B stable stable --track upstream/"$RefStable"
 }
 
-# 6. Pre-load Artifacts
+# 5. Pre-load Artifacts
 # Determine correct flutter command based on OS for cross-platform compatibility
 $flutterCmd = if ($IsWindows) { ".\bin\flutter.bat" } else { "./bin/flutter" }
 if ($setupStable -match "^[yY]") {
@@ -92,7 +88,7 @@ Set-Location master
 & $flutterCmd --version | Out-Null
 Set-Location ..
 
-# 7. Generate The Switcher Script
+# 6. Generate The Switcher Script
 Write-Host "🔗 Generating context switcher..." -ForegroundColor Cyan
 $SwitchFile = Join-Path $RootPath "fswitch.ps1"
 

--- a/setup_flutter.template.sh
+++ b/setup_flutter.template.sh
@@ -37,7 +37,6 @@ git clone --bare "$ORIGIN_URL" .bare
 echo "gitdir: ./.bare" > .git
 
 # 3. Configure Remotes
-cd .bare
 echo "⚙️  Configuring remotes..."
 git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
 git remote add upstream "$UPSTREAM_URL"
@@ -46,9 +45,6 @@ git config remote.upstream.fetch "+refs/heads/*:refs/remotes/upstream/*"
 # 4. Fetch tags / branches
 echo "⬇️  Fetching everything (--all --tags --prune)..."
 git fetch --all --tags --prune
-
-# 5. Create Worktrees
-cd ..
 
 # --- Setup MASTER ---
 echo "🌲 Creating 'master' worktree (tracking upstream/master)..."
@@ -66,7 +62,7 @@ else
     SETUP_STABLE=false
 fi
 
-# 6. Pre-load Artifacts
+# 5. Pre-load Artifacts
 # We run --version to download the engine/dart-sdk for both immediately
 if [ "$SETUP_STABLE" = true ]; then
     echo "🛠️  Hydrating 'stable' artifacts..."
@@ -80,7 +76,7 @@ cd master
 ./bin/flutter --version > /dev/null
 cd ..
 
-# 7. Generate The Switcher Script
+# 6. Generate The Switcher Script
 echo "🔗 Generating context switcher..."
 SWITCH_FILE="$ROOT_PATH/fswitch.sh"
 


### PR DESCRIPTION
fixes #14

When safe.bareRepository is set to explicit, Git prevents running commands inside a bare repository unless it is explicitly specified as the git directory (e.g., via --git-dir). This security feature is designed to prevent accidental execution of git commands in directories that happen to look like git repositories
(e.g., a side-effect of CVE-2022-24765).